### PR TITLE
Add backports.zoneinfo for python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ async-timeout==4.0.2
 attrs==22.1.0
 autobahn==22.7.1
 Automat==20.2.0
+backports.zoneinfo;python_version<"3.9"
 certifi==2022.9.24
 cffi==1.15.1
 channels==4.0.0


### PR DESCRIPTION
https://pypi.org/project/backports.zoneinfo/#description

This fixes a deployment error on Jenkins.