### PR TITLE
Add make target for daphne server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
 APP=mathplayground
 
 include *.mk
+
+daphne: $(PY_SENTINAL)
+	./ve/bin/daphne -b 0.0.0.0 -p 8000 --proxy-headers \
+		mathplayground.asgi:application
+
+.PHONY: daphne


### PR DESCRIPTION
I'm testing out some websockets stuff and seeing the WS connection fail with django's runserver, but daphne works. There's some stuff to figure out here.